### PR TITLE
Rewrite algorithm to maximize optional attendees for meeting queries.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Build files
+target

--- a/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -18,8 +18,8 @@ import java.util.Collection;
 import java.util.ArrayList;
 import java.util.PriorityQueue;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.HashMap;
+import java.util.HashSet;
 
 public final class FindMeetingQuery {
 
@@ -101,10 +101,19 @@ public final class FindMeetingQuery {
         if (finalList == null) {
             return (new ArrayList<TimeRange>());
         }
-
         finalList.sort(TimeRange.ORDER_BY_START);
 
-        return finalList;
+        ArrayList<TimeRange> removeDuplicates = new ArrayList<TimeRange>();
+
+        TimeRange lastAdded = null;
+        for (TimeRange timeRange : finalList) {
+            if (!timeRange.equals(lastAdded)) {
+                removeDuplicates.add(timeRange);
+                lastAdded = timeRange;
+            }
+        }
+
+        return removeDuplicates;
     }
 
     private ArrayList<TimeRange> processTimeRanges(long duration) {

--- a/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -15,6 +15,7 @@
 package com.google.sps;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.ArrayList;
 import java.util.PriorityQueue;
 import java.util.Comparator;
@@ -103,7 +104,7 @@ public final class FindMeetingQuery {
         }
         finalList.sort(TimeRange.ORDER_BY_START);
 
-        ArrayList<TimeRange> removeDuplicates = new ArrayList<TimeRange>();
+        List<TimeRange> removeDuplicates = new ArrayList<TimeRange>();
 
         TimeRange lastAdded = null;
         for (TimeRange timeRange : finalList) {

--- a/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -18,47 +18,44 @@ import java.util.Collection;
 import java.util.ArrayList;
 import java.util.PriorityQueue;
 import java.util.Comparator;
+import java.util.Iterator;
 
 public final class FindMeetingQuery {
 
-    ArrayList<TimeRange> queryResult;
+    private ArrayList<TimeRange> queryResult;
+    private PriorityQueue<Event> guestEventQueue;
+    private PriorityQueue<Event> eventQueue;
 
     public Collection<TimeRange> query(Collection<Event> events,
             MeetingRequest request) {
         queryResult = new ArrayList<TimeRange>();
+        eventQueue =
+            new PriorityQueue<Event>((Event e1, Event e2) ->
+                TimeRange.ORDER_BY_START.compare(e1.getWhen(), e2.getWhen()));
+        guestEventQueue =
+            new PriorityQueue<Event>((Event e1, Event e2) ->
+                TimeRange.ORDER_BY_START.compare(e1.getWhen(), e2.getWhen()));
 
         TimeRange currentRange = TimeRange.WHOLE_DAY;
 
-        PriorityQueue<Event> eventQueue =
-                new PriorityQueue<Event>(new Comparator<Event>() {
-            @Override
-            public int compare(Event e1, Event e2) {
-                return TimeRange.ORDER_BY_START.compare(
-                        e1.getWhen(), e2.getWhen());
-            }
-        });
-
-        for (Event event : events) {
-            if (eventIntersectsGuestlist(event, request.getAttendees())) {
-                eventQueue.add(event);
-            }
-        }
+        checkEvents(events, request.getAttendees(),
+            request.getOptionalAttendees());
 
         while (!eventQueue.isEmpty()) {
-            TimeRange currentEvent = eventQueue.poll().getWhen();
+            TimeRange currentEventTimeRange = eventQueue.poll().getWhen();
 
-            if (!currentEvent.overlaps(currentRange)) {
+            if (!currentEventTimeRange.overlaps(currentRange)) {
                 continue;
             }
 
             TimeRange addRange = TimeRange.fromStartEnd(currentRange.start(),
-                                 currentEvent.start(), false);
+                                 currentEventTimeRange.start(), false);
 
             if (addRange.duration() >= request.getDuration()) {
                 queryResult.add(addRange);
             }
 
-            currentRange = TimeRange.fromStartEnd(currentEvent.end(),
+            currentRange = TimeRange.fromStartEnd(currentEventTimeRange.end(),
                            currentRange.end(), false);
             if (currentRange.duration() <= 0) {
                 break;
@@ -69,19 +66,151 @@ public final class FindMeetingQuery {
             queryResult.add(currentRange);
         }
 
-        return queryResult;
+        Collection<TimeRange> optionalCheck = considerOptional(
+            request.getDuration());
+
+        if (optionalCheck.isEmpty()) {
+            return queryResult;
+        }
+
+        return optionalCheck;
     }
 
-    private boolean eventIntersectsGuestlist(Event event,
-            Collection<String> guestList) {
-        Collection<String> eventGuestlist = event.getAttendees();
+    private Collection<TimeRange> considerOptional(long duration) {
+        ArrayList<TimeRange> optionalResult = new ArrayList<TimeRange>();
 
-        for (String name : guestList) {
-            if (eventGuestlist.contains(name)) {
-                return true;
+        if (queryResult.isEmpty()) {
+            return optionalResult;
+        }
+
+        if (guestEventQueue.isEmpty()) {
+            return optionalResult;
+        }
+
+        Iterator<TimeRange> availableRangeIterator = queryResult.iterator();
+        TimeRange workingTimeRange = availableRangeIterator.next();
+        TimeRange currentEventTimeRange = guestEventQueue.poll().getWhen();
+
+        eventIteration:
+        while (true) {
+
+            if (workingTimeRange.start() >= currentEventTimeRange.end()) {
+                if (guestEventQueue.isEmpty()) {
+                    break eventIteration;
+                }
+
+                currentEventTimeRange = guestEventQueue.poll().getWhen();
+            }
+
+            while (!currentEventTimeRange.overlaps(workingTimeRange)
+                    && workingTimeRange.start() < currentEventTimeRange.end()) {
+                if (!availableRangeIterator.hasNext()) {
+                    // Might be able too immediately return here.
+                    break eventIteration;
+                }
+
+                optionalResult.add(workingTimeRange);
+                workingTimeRange = availableRangeIterator.next();
+            }
+
+            if (currentEventTimeRange.overlaps(workingTimeRange)) {
+                TimeRange[] rangeCut = handleOverlap(
+                    currentEventTimeRange, workingTimeRange, duration);
+
+                if (rangeCut[0] != null) {
+                    optionalResult.add(rangeCut[0]);
+                }
+                if (rangeCut[1] != null) {
+                    workingTimeRange = rangeCut[1];
+                }
+                else {
+                    if (!availableRangeIterator.hasNext()) {
+                        workingTimeRange = null;
+                        break eventIteration;
+                    }
+
+                    workingTimeRange = availableRangeIterator.next();
+                }
             }
         }
 
-        return false;
+        while (workingTimeRange != null) {
+            optionalResult.add(workingTimeRange);
+
+            if (availableRangeIterator.hasNext()) {
+                workingTimeRange = availableRangeIterator.next();
+            }
+            else {
+                workingTimeRange = null;
+            }
+        }
+
+        return optionalResult;
+    }
+
+    private TimeRange[] handleOverlap(TimeRange eventRange,
+            TimeRange workingRange, long duration) {
+        TimeRange[] returnRange = new TimeRange[2];
+
+        if (eventRange.contains(workingRange)) {
+            return returnRange;
+        }
+        else if (workingRange.contains(eventRange)) {
+            TimeRange before = TimeRange.fromStartEnd(workingRange.start(),
+                eventRange.start(), false);
+            TimeRange after = TimeRange.fromStartEnd(eventRange.end(),
+                workingRange.end(), false);
+
+            if (before.duration() >= duration) {
+                returnRange[0] = before;
+            }
+            if (after.duration() >= duration) {
+                returnRange[1] = after;
+            }
+        }
+        else if (workingRange.start() < eventRange.start()) {
+            TimeRange trimRange = TimeRange.fromStartEnd(workingRange.start(),
+                eventRange.start(), false);
+
+            if (trimRange.duration() >= duration) {
+                returnRange[0] = trimRange;
+            }
+        }
+        else {
+            TimeRange trimRange = TimeRange.fromStartEnd(eventRange.end(),
+                workingRange.end(), false);
+
+            if (trimRange.duration() >= duration) {
+                returnRange[1] = trimRange;
+            }
+        }
+
+        return returnRange;
+    }
+
+    private void checkEvents(Collection<Event> events,
+            Collection<String> guestList, Collection<String> optionalList) {
+
+        for (Event event : events) {
+            Collection<String> eventGuestList = event.getAttendees();
+            boolean hasAttendee = false;
+            boolean hasOptionalAttendee = false;
+
+            for (String guest : eventGuestList) {
+                if (guestList.contains(guest)) {
+                    hasAttendee = true;
+                }
+                if (optionalList.contains(guest)) {
+                    hasOptionalAttendee = true;
+                }
+            }
+
+            if (hasAttendee) {
+                eventQueue.add(event);
+            }
+            else if (hasOptionalAttendee) {
+                guestEventQueue.add(event);
+            }
+        }
     }
 }

--- a/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -35,6 +35,7 @@ public final class FindMeetingQueryTest {
     private static final String PERSON_A = "Person A";
     private static final String PERSON_B = "Person B";
     private static final String PERSON_C = "Person C";
+    private static final String PERSON_D = "Person D";
 
     // All dates are the first day of the year 2020.
     private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
@@ -154,6 +155,79 @@ public final class FindMeetingQueryTest {
             TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
             TimeRange.fromStartEnd(TIME_0930AM,
             TimeRange.END_OF_DAY, true));
+
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void cascadingAvailabilityOptional() {
+        Collection<Event> events = Arrays.asList(
+            new Event("Event 1", TimeRange.fromStartEnd(0, 1440, false),
+                Arrays.asList(PERSON_B)),
+            new Event("Event 2", TimeRange.fromStartEnd(480, 1440, false),
+                Arrays.asList(PERSON_C)),
+            new Event("Event 3", TimeRange.fromStartEnd(960, 1440, false),
+                Arrays.asList(PERSON_D)));
+
+        MeetingRequest request = new MeetingRequest(
+            Arrays.asList(PERSON_A), 960);
+        request.addOptionalAttendee(PERSON_B);
+        request.addOptionalAttendee(PERSON_C);
+        request.addOptionalAttendee(PERSON_D);
+
+        Collection<TimeRange> actual = query.query(events, request);
+        Collection<TimeRange> expected =
+            Arrays.asList(TimeRange.fromStartEnd(0, 960, false));
+
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void optionalAttendeesSwap() {
+        Collection<Event> events = Arrays.asList(
+            new Event("Event 1", TimeRange.fromStartEnd(0, 720, false),
+                Arrays.asList(PERSON_B)),
+            new Event("Event 2", TimeRange.fromStartEnd(720, 1440, false),
+                Arrays.asList(PERSON_C)));
+
+        MeetingRequest request = new MeetingRequest(
+            Arrays.asList(PERSON_A), DURATION_1_HOUR);
+        request.addOptionalAttendee(PERSON_B);
+        request.addOptionalAttendee(PERSON_C);
+
+        Collection<TimeRange> actual = query.query(events, request);
+        Collection<TimeRange> expected1 =
+            Arrays.asList(TimeRange.fromStartEnd(0,720,false));
+        Collection<TimeRange> expected2 =
+            Arrays.asList(TimeRange.fromStartEnd(720,1440,false));
+
+        boolean equalsExpected1 = actual.containsAll(expected1) &&
+            expected1.containsAll(actual);
+
+        boolean equalsExpected2 = actual.containsAll(expected2) &&
+            expected2.containsAll(actual);
+
+        Assert.assertTrue(actual.toString() + " does not equal: " +
+            expected1.toString() + " or " + expected2.toString(),
+            equalsExpected1 || equalsExpected2);
+    }
+
+    @Test
+    public void optionalAttendeeOptimalSlotOverlap() {
+        Collection<Event> events = Arrays.asList(
+            new Event("Event 1", TimeRange.fromStartEnd(0, 576, false),
+                Arrays.asList(PERSON_B)),
+            new Event("Event 2", TimeRange.fromStartEnd(864, 1440, false),
+                Arrays.asList(PERSON_B)));
+
+        MeetingRequest request = new MeetingRequest(
+            Arrays.asList(PERSON_A), 576);
+        request.addOptionalAttendee(PERSON_B);
+        request.addOptionalAttendee(PERSON_C);
+
+        Collection<TimeRange> actual = query.query(events, request);
+        Collection<TimeRange> expected = Arrays.asList(
+            TimeRange.WHOLE_DAY);
 
         Assert.assertEquals(expected, actual);
     }

--- a/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -28,247 +28,356 @@ import org.junit.runners.JUnit4;
 /** */
 @RunWith(JUnit4.class)
 public final class FindMeetingQueryTest {
-  private static final Collection<Event> NO_EVENTS = Collections.emptySet();
-  private static final Collection<String> NO_ATTENDEES = Collections.emptySet();
+    private static final Collection<Event> NO_EVENTS = Collections.emptySet();
+    private static final Collection<String> NO_ATTENDEES = Collections.emptySet();
 
-  // Some people that we can use in our tests.
-  private static final String PERSON_A = "Person A";
-  private static final String PERSON_B = "Person B";
+    // Some people that we can use in our tests.
+    private static final String PERSON_A = "Person A";
+    private static final String PERSON_B = "Person B";
+    private static final String PERSON_C = "Person C";
 
-  // All dates are the first day of the year 2020.
-  private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
-  private static final int TIME_0830AM = TimeRange.getTimeInMinutes(8, 30);
-  private static final int TIME_0900AM = TimeRange.getTimeInMinutes(9, 0);
-  private static final int TIME_0930AM = TimeRange.getTimeInMinutes(9, 30);
-  private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
-  private static final int TIME_1100AM = TimeRange.getTimeInMinutes(11, 00);
+    // All dates are the first day of the year 2020.
+    private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
+    private static final int TIME_0830AM = TimeRange.getTimeInMinutes(8, 30);
+    private static final int TIME_0900AM = TimeRange.getTimeInMinutes(9, 0);
+    private static final int TIME_0930AM = TimeRange.getTimeInMinutes(9, 30);
+    private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
+    private static final int TIME_1100AM = TimeRange.getTimeInMinutes(11, 00);
 
-  private static final int DURATION_30_MINUTES = 30;
-  private static final int DURATION_60_MINUTES = 60;
-  private static final int DURATION_90_MINUTES = 90;
-  private static final int DURATION_1_HOUR = 60;
-  private static final int DURATION_2_HOUR = 120;
+    private static final int DURATION_15_MINUTES = 15;
+    private static final int DURATION_30_MINUTES = 30;
+    private static final int DURATION_60_MINUTES = 60;
+    private static final int DURATION_90_MINUTES = 90;
+    private static final int DURATION_1_HOUR = 60;
+    private static final int DURATION_2_HOUR = 120;
 
-  private FindMeetingQuery query;
+    private FindMeetingQuery query;
 
-  @Before
-  public void setUp() {
-    query = new FindMeetingQuery();
-  }
+    @Before
+    public void setUp() {
+        query = new FindMeetingQuery();
+    }
 
-  @Test
-  public void optionsForNoAttendees() {
-    MeetingRequest request = new MeetingRequest(NO_ATTENDEES, DURATION_1_HOUR);
+    @Test
+    public void optionsForNoAttendees() {
+        MeetingRequest request = new MeetingRequest(NO_ATTENDEES, DURATION_1_HOUR);
 
-    Collection<TimeRange> actual = query.query(NO_EVENTS, request);
-    Collection<TimeRange> expected = Arrays.asList(TimeRange.WHOLE_DAY);
+        Collection<TimeRange> actual = query.query(NO_EVENTS, request);
+        Collection<TimeRange> expected = Arrays.asList(TimeRange.WHOLE_DAY);
 
-    Assert.assertEquals(expected, actual);
-  }
+        Assert.assertEquals(expected, actual);
+    }
 
-  @Test
-  public void noOptionsForTooLongOfARequest() {
-    // The duration should be longer than a day. This means there should be no options.
-    int duration = TimeRange.WHOLE_DAY.duration() + 1;
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), duration);
+    @Test
+    public void noOptionsForTooLongOfARequest() {
+        // The duration should be longer than a day. This means there should be no options.
+        int duration = TimeRange.WHOLE_DAY.duration() + 1;
+        MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), duration);
 
-    Collection<TimeRange> actual = query.query(NO_EVENTS, request);
-    Collection<TimeRange> expected = Arrays.asList();
+        Collection<TimeRange> actual = query.query(NO_EVENTS, request);
+        Collection<TimeRange> expected = Arrays.asList();
 
-    Assert.assertEquals(expected, actual);
-  }
+        Assert.assertEquals(expected, actual);
+    }
 
-  @Test
-  public void eventSplitsRestriction() {
-    // The event should split the day into two options (before and after the event).
-    Collection<Event> events = Arrays.asList(new Event("Event 1",
-        TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES), Arrays.asList(PERSON_A)));
+    @Test
+    public void onlyOptionalAttendeesBusy() {
+        Collection<Event> events = Arrays.asList(
+            new Event("Event 1", TimeRange.WHOLE_DAY, Arrays.asList(PERSON_A)),
+            new Event("Event 2", TimeRange.WHOLE_DAY, Arrays.asList(PERSON_B)));
 
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+        MeetingRequest request = new MeetingRequest(NO_ATTENDEES, DURATION_1_HOUR);
+        request.addOptionalAttendee(PERSON_A);
+        request.addOptionalAttendee(PERSON_B);
 
-    Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-            TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true));
+        Collection<TimeRange> actual = query.query(events, request);
+        Collection<TimeRange> expected = Arrays.asList(TimeRange.WHOLE_DAY);
 
-    Assert.assertEquals(expected, actual);
-  }
+        Assert.assertEquals(expected, actual);
+    }
 
-  @Test
-  public void everyAttendeeIsConsidered() {
-    // Have each person have different events. We should see two options because each person has
-    // split the restricted times.
-    //
-    // Events  :       |--A--|     |--B--|
-    // Day     : |-----------------------------|
-    // Options : |--1--|     |--2--|     |--3--|
+    @Test
+    public void onlyOptionalAttendees() {
+        Collection<Event> events = Arrays.asList(
+            new Event("Event 1", TimeRange.fromStartDuration(TIME_0900AM,
+                DURATION_1_HOUR), Arrays.asList(PERSON_A)),
+            new Event("Event 2", TimeRange.fromStartDuration(TIME_0830AM,
+                DURATION_1_HOUR), Arrays.asList(PERSON_B)));
 
-    Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
-            Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
-            Arrays.asList(PERSON_B)));
+        MeetingRequest request =
+            new MeetingRequest(NO_ATTENDEES, DURATION_1_HOUR);
+        request.addOptionalAttendee(PERSON_A);
+        request.addOptionalAttendee(PERSON_B);
 
-    MeetingRequest request =
-        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+        Collection<TimeRange> actual = query.query(events, request);
+        Collection<TimeRange> expected =
+            Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY,
+            TIME_0830AM, false), TimeRange.fromStartEnd(TIME_1000AM,
+            TimeRange.END_OF_DAY, true));
 
-    Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void eventSplitsRestriction() {
+        // The event should split the day into two options (before and after the event).
+        Collection<Event> events = Arrays.asList(new Event("Event 1",
+            TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES), Arrays.asList(PERSON_A)));
+
+        MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+
+        Collection<TimeRange> actual = query.query(events, request);
+        Collection<TimeRange> expected =
+            Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+                TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true));
+
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void optionalAttendeeDayEvent() {
+        Collection<Event> events = Arrays.asList(
+            new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM,
+                DURATION_30_MINUTES), Arrays.asList(PERSON_A)),
+            new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM,
+                DURATION_30_MINUTES), Arrays.asList(PERSON_B)),
+            new Event("Event 3", TimeRange.WHOLE_DAY, Arrays.asList(PERSON_C)));
+
+        MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A,
+            PERSON_B), DURATION_30_MINUTES);
+        request.addOptionalAttendee(PERSON_C);
+
+        Collection<TimeRange> actual = query.query(events, request);
+        Collection<TimeRange> expected =
+            Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY,
+            TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM,
+            TimeRange.END_OF_DAY, true));
+
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void optionalAttendeeRemovesSlot() {
+        // Have an optional attendee C that has an event between 8:30 and 9:30.
+        Collection<Event> events = Arrays.asList(
+            new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM,
+                DURATION_30_MINUTES), Arrays.asList(PERSON_A)),
+            new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM,
+                DURATION_30_MINUTES), Arrays.asList(PERSON_B)),
+            new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM,
+                DURATION_1_HOUR), Arrays.asList(PERSON_C)));
+
+        MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A,
+            PERSON_B), DURATION_30_MINUTES);
+        request.addOptionalAttendee(PERSON_C);
+
+        Collection<TimeRange> actual = query.query(events, request);
+        Collection<TimeRange> expected =
+            Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY,
+            TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void everyAttendeeIsConsidered() {
+        // Have each person have different events. We should see two options because each person has
+        // split the restricted times.
+        //
+        // Events  :       |--A--|     |--B--|
+        // Day     : |-----------------------------|
+        // Options : |--1--|     |--2--|     |--3--|
+
+        Collection<Event> events = Arrays.asList(
+            new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_A)),
+            new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_B)));
+
+        MeetingRequest request =
+            new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+
+        Collection<TimeRange> actual = query.query(events, request);
+        Collection<TimeRange> expected =
+            Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
             TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
             TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
 
-    Assert.assertEquals(expected, actual);
-  }
+        Assert.assertEquals(expected, actual);
+    }
 
-  @Test
-  public void overlappingEvents() {
-    // Have an event for each person, but have their events overlap. We should only see two options.
-    //
-    // Events  :       |--A--|
-    //                     |--B--|
-    // Day     : |---------------------|
-    // Options : |--1--|         |--2--|
+    @Test
+    public void overlappingEvents() {
+        // Have an event for each person, but have their events overlap. We should only see two options.
+        //
+        // Events  :       |--A--|
+        //                     |--B--|
+        // Day     : |---------------------|
+        // Options : |--1--|         |--2--|
 
-    Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
-            Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_60_MINUTES),
-            Arrays.asList(PERSON_B)));
+        Collection<Event> events = Arrays.asList(
+            new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
+                Arrays.asList(PERSON_A)),
+            new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_60_MINUTES),
+                Arrays.asList(PERSON_B)));
 
-    MeetingRequest request =
-        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+        MeetingRequest request =
+            new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
-    Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        Collection<TimeRange> actual = query.query(events, request);
+        Collection<TimeRange> expected =
+            Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
 
-    Assert.assertEquals(expected, actual);
-  }
+        Assert.assertEquals(expected, actual);
+    }
 
-  @Test
-  public void nestedEvents() {
-    // Have an event for each person, but have one person's event fully contain another's event. We
-    // should see two options.
-    //
-    // Events  :       |----A----|
-    //                   |--B--|
-    // Day     : |---------------------|
-    // Options : |--1--|         |--2--|
+    @Test
+    public void nestedEvents() {
+        // Have an event for each person, but have one person's event fully contain another's event. We
+        // should see two options.
+        //
+        // Events  :       |----A----|
+        //                   |--B--|
+        // Day     : |---------------------|
+        // Options : |--1--|         |--2--|
 
-    Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_90_MINUTES),
-            Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
-            Arrays.asList(PERSON_B)));
+        Collection<Event> events = Arrays.asList(
+            new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_90_MINUTES),
+                Arrays.asList(PERSON_A)),
+            new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_B)));
 
-    MeetingRequest request =
-        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+        MeetingRequest request =
+            new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
-    Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        Collection<TimeRange> actual = query.query(events, request);
+        Collection<TimeRange> expected =
+            Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
 
-    Assert.assertEquals(expected, actual);
-  }
+        Assert.assertEquals(expected, actual);
+    }
 
-  @Test
-  public void doubleBookedPeople() {
-    // Have one person, but have them registered to attend two events at the same time.
-    //
-    // Events  :       |----A----|
-    //                     |--A--|
-    // Day     : |---------------------|
-    // Options : |--1--|         |--2--|
+    @Test
+    public void doubleBookedPeople() {
+        // Have one person, but have them registered to attend two events at the same time.
+        //
+        // Events  :       |----A----|
+        //                     |--A--|
+        // Day     : |---------------------|
+        // Options : |--1--|         |--2--|
 
-    Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
-            Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
-            Arrays.asList(PERSON_A)));
+        Collection<Event> events = Arrays.asList(
+            new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
+                Arrays.asList(PERSON_A)),
+            new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_A)));
 
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+        MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
 
-    Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        Collection<TimeRange> actual = query.query(events, request);
+        Collection<TimeRange> expected =
+            Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
 
-    Assert.assertEquals(expected, actual);
-  }
+        Assert.assertEquals(expected, actual);
+    }
 
-  @Test
-  public void justEnoughRoom() {
-    // Have one person, but make it so that there is just enough room at one point in the day to
-    // have the meeting.
-    //
-    // Events  : |--A--|     |----A----|
-    // Day     : |---------------------|
-    // Options :       |-----|
+    @Test
+    public void justEnoughRoom() {
+        // Have one person, but make it so that there is just enough room at one point in the day to
+        // have the meeting.
+        //
+        // Events  : |--A--|     |----A----|
+        // Day     : |---------------------|
+        // Options :       |-----|
 
-    Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-            Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
-            Arrays.asList(PERSON_A)));
+        Collection<Event> events = Arrays.asList(
+            new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+                Arrays.asList(PERSON_A)),
+            new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+                Arrays.asList(PERSON_A)));
 
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+        MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
 
-    Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+        Collection<TimeRange> actual = query.query(events, request);
+        Collection<TimeRange> expected =
+            Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
 
-    Assert.assertEquals(expected, actual);
-  }
+        Assert.assertEquals(expected, actual);
+    }
 
-  @Test
-  public void ignoresPeopleNotAttending() {
-    // Add an event, but make the only attendee someone different from the person looking to book
-    // a meeting. This event should not affect the booking.
-    Collection<Event> events = Arrays.asList(new Event("Event 1",
-        TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES), Arrays.asList(PERSON_A)));
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_B), DURATION_30_MINUTES);
+    @Test
+    public void optionalAttendeeRestrictsTime() {
+        Collection<Event> events = Arrays.asList(
+            new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY,
+                TIME_0830AM, false), Arrays.asList(PERSON_A)),
+            new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM,
+                TimeRange.END_OF_DAY, true), Arrays.asList(PERSON_A)),
+            new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM,
+                DURATION_15_MINUTES), Arrays.asList(PERSON_B)));
 
-    Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected = Arrays.asList(TimeRange.WHOLE_DAY);
+        MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A),
+            DURATION_30_MINUTES);
+        request.addOptionalAttendee(PERSON_B);
 
-    Assert.assertEquals(expected, actual);
-  }
+        Collection<TimeRange> actual = query.query(events, request);
+        Collection<TimeRange> expected =
+            Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM,
+            DURATION_30_MINUTES));
 
-  @Test
-  public void noConflicts() {
-    MeetingRequest request =
-        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+        Assert.assertEquals(expected, actual);
+    }
 
-    Collection<TimeRange> actual = query.query(NO_EVENTS, request);
-    Collection<TimeRange> expected = Arrays.asList(TimeRange.WHOLE_DAY);
+    @Test
+    public void ignoresPeopleNotAttending() {
+        // Add an event, but make the only attendee someone different from the person looking to book
+        // a meeting. This event should not affect the booking.
+        Collection<Event> events = Arrays.asList(new Event("Event 1",
+            TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES), Arrays.asList(PERSON_A)));
+        MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_B), DURATION_30_MINUTES);
 
-    Assert.assertEquals(expected, actual);
-  }
+        Collection<TimeRange> actual = query.query(events, request);
+        Collection<TimeRange> expected = Arrays.asList(TimeRange.WHOLE_DAY);
 
-  @Test
-  public void notEnoughRoom() {
-    // Have one person, but make it so that there is not enough room at any point in the day to
-    // have the meeting.
-    //
-    // Events  : |--A-----| |-----A----|
-    // Day     : |---------------------|
-    // Options :
+        Assert.assertEquals(expected, actual);
+    }
 
-    Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-            Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
-            Arrays.asList(PERSON_A)));
+    @Test
+    public void noConflicts() {
+        MeetingRequest request =
+            new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
+        Collection<TimeRange> actual = query.query(NO_EVENTS, request);
+        Collection<TimeRange> expected = Arrays.asList(TimeRange.WHOLE_DAY);
 
-    Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected = Arrays.asList();
+        Assert.assertEquals(expected, actual);
+    }
 
-    Assert.assertEquals(expected, actual);
-  }
+    @Test
+    public void notEnoughRoom() {
+        // Have one person, but make it so that there is not enough room at any point in the day to
+        // have the meeting.
+        //
+        // Events  : |--A-----| |-----A----|
+        // Day     : |---------------------|
+        // Options :
+
+        Collection<Event> events = Arrays.asList(
+            new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+                Arrays.asList(PERSON_A)),
+            new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+                Arrays.asList(PERSON_A)));
+
+        MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
+
+        Collection<TimeRange> actual = query.query(events, request);
+        Collection<TimeRange> expected = Arrays.asList();
+
+        Assert.assertEquals(expected, actual);
+    }
 }
-


### PR DESCRIPTION
The last commit completely changes the algorithm for finding time ranges given a meeting query. (The previous pull request was closed as the algorithm was changed). There are two initial preprocessing steps in the given data. The first splits each event into two event points (start and end), these are placed in a sorted list. The list is iterated through creating TimeRanges with the smallest time intervals necessary to partition the day. The last step expands (in order of TimeRanges with the largest number of optional attendees) to see how far into other partitions of the day the current TimeRange can expand in a contiguous fashion. Since this step is done in a PriorityQueue and whenever a TimeRange is found that satisfies the duration, this guarantees that the returned range has the maximal number of optional attendees.